### PR TITLE
feat: QueryTable Update

### DIFF
--- a/.changeset/gorgeous-dancers-tell.md
+++ b/.changeset/gorgeous-dancers-tell.md
@@ -1,0 +1,5 @@
+---
+"gboost-ui": patch
+---
+
+QueryTable's Flex now has width 100%. Make QueryTable's filters and sorts props more flexibly typed for requiring literals on server (tRPC)

--- a/packages/gboost-ui/src/QueryTable/ActionBar/FilterAction/FilterAction.tsx
+++ b/packages/gboost-ui/src/QueryTable/ActionBar/FilterAction/FilterAction.tsx
@@ -40,12 +40,12 @@ export function FilterAction<T extends Row>(
     const filterColumnIds = filterColumns.map((f) => f.id).join(", ");
     if (!initFilters) {
       console.warn(
-        `filterOptions were set for column(s): ${filterColumnIds} but filter wasn't passed to QueryTable as a prop`
+        `filterOptions were set for column(s): ${filterColumnIds} but filters wasn't passed to QueryTable as a prop`
       );
     }
     if (!onChangeFilters) {
       console.warn(
-        `filterOptions were set for column(s): ${filterColumnIds} but onChangeFilter wasn't passed to QueryTable as a prop`
+        `filterOptions were set for column(s): ${filterColumnIds} but onChangeFilters wasn't passed to QueryTable as a prop`
       );
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/gboost-ui/src/QueryTable/QueryTable.tsx
+++ b/packages/gboost-ui/src/QueryTable/QueryTable.tsx
@@ -129,7 +129,7 @@ export function QueryTable<T extends Row>(
     );
   }
   return (
-    <Flex direction="column" gap="small" position="relative">
+    <Flex direction="column" gap="small" position="relative" width="100%">
       {bgLoading && <BgLoading />}
       {ActionBar}
       <StyledTable

--- a/packages/gboost-ui/src/QueryTable/TableHeader.tsx
+++ b/packages/gboost-ui/src/QueryTable/TableHeader.tsx
@@ -1,4 +1,4 @@
-import { RefObject, ReactElement, useCallback } from "react";
+import { RefObject, ReactElement, useCallback, useEffect } from "react";
 import { TableHeaderCell } from "./TableHeaderCell.js";
 import { SelectionHeader } from "./SelectionHeader.js";
 import { styled } from "../stitches.config.js";
@@ -46,6 +46,25 @@ export function TableHeader<T extends Row>(
     sorts,
     visibleColumns,
   } = props;
+  useEffect(() => {
+    const sortColumnIds = visibleColumns
+      .filter((c) => c.sortable)
+      .map((c) => c.id)
+      .join(",");
+    if (sortColumnIds) {
+      if (!sorts) {
+        console.warn(
+          `sortable was set to true for column(s): ${sortColumnIds} but sorts wasn't passed to QueryTable as a prop`
+        );
+      }
+      if (!onChangeSorts) {
+        console.warn(
+          `sortable was set to true for column(s): ${sortColumnIds} but onChangeSorts wasn't passed to QueryTable as a prop`
+        );
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
   const handleSelectAll = useCallback(() => {
     if (onChangeSelected && selected) {
       onChangeSelected({

--- a/packages/gboost-ui/src/QueryTable/types/filter.ts
+++ b/packages/gboost-ui/src/QueryTable/types/filter.ts
@@ -1,7 +1,7 @@
 export interface Filter {
-  columnId: any;
-  comparator: any;
-  value: any;
+  columnId: any; // allows literal string typing by tRPC schema
+  comparator: any; // allows literal string typing by tRPC schema
+  value: any; // allows literal string typing by tRPC schema
 }
 export interface ColumnOption {
   id: string;

--- a/packages/gboost-ui/src/QueryTable/types/props.ts
+++ b/packages/gboost-ui/src/QueryTable/types/props.ts
@@ -55,7 +55,7 @@ export interface QueryTableProps<T extends Row> {
   heading?: string;
   /**
    * Record with keys being column ids. Default show all columns
-   * @default columns.reduce((prev, cur) => ({ ...prev, [cur.id]: true }), {})
+   * @default `columns.reduce((prev, cur) => ({ ...prev, [cur.id]: true }), {})`
    */
   initColumnVisibility?: Record<string, boolean>;
   /**

--- a/packages/gboost-ui/src/QueryTable/types/sort.ts
+++ b/packages/gboost-ui/src/QueryTable/types/sort.ts
@@ -1,6 +1,6 @@
 export type SortDirection = "asc" | "desc";
 
 export interface Sort {
-  columnId: string;
+  columnId: any; // allows literal string typing by tRPC schema
   direction: SortDirection;
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Make `QueryTable`'s "oldest" `Flex` width of 100%. Update props: `filters` and `sorts` to be more flexible to allow string literal types on server (works better with tRPC).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
