### PR TITLE
fix(gboost-infra): suppressAwsLambdaBasicExecutionRole to handle empt…

### DIFF
--- a/.changeset/brave-pumpkins-rhyme.md
+++ b/.changeset/brave-pumpkins-rhyme.md
@@ -1,0 +1,5 @@
+---
+"gboost-infra": patch
+---
+
+Fix `suppressAwsLambdaBasicExecutionRole` to handle empty `managedPolicyArn` array

--- a/packages/gboost-infra/src/aspects/suppress-nags/suppress-aws-lambda-basic-execution-role.ts
+++ b/packages/gboost-infra/src/aspects/suppress-nags/suppress-aws-lambda-basic-execution-role.ts
@@ -20,9 +20,8 @@ export function suppressAwsLambdaBasicExecutionRole(construct: IConstruct) {
         }]
      * ```
      */
-    const managedPolicyArns = Stack.of(construct).resolve(
-      construct.managedPolicyArns
-    );
+    const managedPolicyArns =
+      Stack.of(construct).resolve(construct.managedPolicyArns) || [];
     for (const managedPolicyArn of managedPolicyArns) {
       const endOfArn = managedPolicyArn?.["Fn::Join"]?.at(-1)?.at(-1);
       if (endOfArn?.endsWith("AWSLambdaBasicExecutionRole")) {


### PR DESCRIPTION
…y managedPolicyArn array

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
