### PR TITLE
fix(gboost-ui): LayoutGrid bug when leftAside is not set

### DIFF
--- a/.changeset/gentle-cups-unite.md
+++ b/.changeset/gentle-cups-unite.md
@@ -1,0 +1,5 @@
+---
+"gboost-ui": patch
+---
+
+Fix `LayoutGrid` so that it does not require `leftAsideArea`

--- a/packages/gboost-ui/src/components/Layout/LayoutGrid.tsx
+++ b/packages/gboost-ui/src/components/Layout/LayoutGrid.tsx
@@ -46,7 +46,7 @@ export const LayoutGrid = forwardRef<HTMLDivElement, LayoutGridProps>(
       }
       return `"${row1}" "${row2}" "${row3}"`;
     }, [leftAsideArea, rightAsideArea]);
-    const templateRows = useMemo<GridProps["templateRows"]>(() => {
+    const templateColumns = useMemo<GridProps["templateRows"]>(() => {
       let templateRows = "1fr";
       if (leftAsideArea) {
         templateRows = "auto " + templateRows;
@@ -60,8 +60,8 @@ export const LayoutGrid = forwardRef<HTMLDivElement, LayoutGridProps>(
       <Grid
         height="100vh"
         templateAreas={templateAreas}
-        templateRows={templateRows}
-        templateColumns={templateRows}
+        templateRows="auto 1fr auto"
+        templateColumns={templateColumns}
         {...rest}
         ref={ref}
       >


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
