### PR TITLE
Validate App Id input vs NPM Spec and normalize DB user/name to SQL spec.

### DIFF
--- a/.changeset/silver-taxis-count.md
+++ b/.changeset/silver-taxis-count.md
@@ -1,0 +1,5 @@
+---
+"gboost": patch
+---
+
+Validate AppId input against NPM Spec, and normalize DB user, name against SQL Spec

--- a/packages/gboost/src/create/ask.ts
+++ b/packages/gboost/src/create/ask.ts
@@ -41,13 +41,14 @@ const questions: PromptObject<keyof Answers>[] = [
     name: "appId",
     type: "text",
     // Part of CDK Stack name and used as scope to prefix all PNPM workspaces within monorepo
-    message: "App ID (lowercase alphanumeric and hyphens):",
+    // Also cloud formation stacks name restrictions only allow alphanumeric and hyphens
+    message: "App ID (lowercase alphanumeric and hyphens only):",
     initial: "myapp",
     validate(v) {
-      if (/[a-z0-9-_]+/g.test(v)) {
+      if (/^[a-z][a-z0-9-]*$/g.test(v)) {
         return true;
       } else {
-        return "App ID must be lowercase alphanumeric and can include hyphens.";
+        return "App ID must begin with a lowercase character and contain only alphanumeric characters with hyphens";
       }
     },
     onState: handleAborted,

--- a/packages/gboost/templates/crud-postgres/core/src/config/stage-config.ts
+++ b/packages/gboost/templates/crud-postgres/core/src/config/stage-config.ts
@@ -37,13 +37,18 @@ export class StageConfig extends CommonStageConfig {
     super(stageName);
     this.stageName = stageName;
   }
+
+  /* replace dashs with underscores to comply with SQL Naming conventions. */
+  #normalizeForDb(name: string) {
+    return name.replaceAll("-", "_");
+  }
   get dbAdminUsername() {
-    return `${this.appId}_admin`;
+    return this.#normalizeForDb(`${this.appId}_admin`);
   }
   get dbIamUsername() {
     return `${this.appId}_iam_user`;
   }
   get dbName() {
-    return `${this.appId}_db`;
+    return this.#normalizeForDb(`${this.appId}_db`);
   }
 }


### PR DESCRIPTION
Issue #271

Validated App Id input for alphanumeric/hyphen.
Added DB name/admin username normalization to SQL name spec (changed hyphens to underscores)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
