### PR TITLE
Add DB IAM Username normalization and vitest fix

### DIFF
--- a/.changeset/tricky-starfishes-behave.md
+++ b/.changeset/tricky-starfishes-behave.md
@@ -1,0 +1,5 @@
+---
+"gboost": patch
+---
+
+Fixed DB IAM Username normalization

--- a/packages/gboost/.lintstagedrc.js
+++ b/packages/gboost/.lintstagedrc.js
@@ -3,6 +3,6 @@ import { removeIgnoredFiles } from "../../utils/lintStaged.js"
 export default {
   "*.ts": async (files) => {
     const filesToLint = await removeIgnoredFiles(files);
-    return [`eslint --fix --max-warnings=0 ${filesToLint}`, `vitest related ${files}`, "tsc --noEmit"];
+    return [`eslint --fix --max-warnings=0 ${filesToLint}`, `vitest related ${files} --run`, "tsc --noEmit"];
   }
 }

--- a/packages/gboost/templates/crud-postgres/core/src/config/stage-config.ts
+++ b/packages/gboost/templates/crud-postgres/core/src/config/stage-config.ts
@@ -46,9 +46,10 @@ export class StageConfig extends CommonStageConfig {
     return this.#normalizeForDb(`${this.appId}_admin`);
   }
   get dbIamUsername() {
-    return `${this.appId}_iam_user`;
+    return this.#normalizeForDb(`${this.appId}_iam_user`);
   }
   get dbName() {
     return this.#normalizeForDb(`${this.appId}_db`);
   }
 }
+


### PR DESCRIPTION
Part if issues 217, add db name normalization for DB IAM user in postgres stage conf.
Also fixed vitest hanging on commit by adding --run option to vitest command.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
