### PR TITLE
fix(gboost) resolves #234 git check fail due to -v vs --version

### DIFF
--- a/.changeset/brave-radios-joke.md
+++ b/.changeset/brave-radios-joke.md
@@ -1,0 +1,5 @@
+---
+"gboost": patch
+---
+
+fix git check of `gboost create` to support all versions of git

--- a/packages/gboost/src/create/index.ts
+++ b/packages/gboost/src/create/index.ts
@@ -53,7 +53,7 @@ function ensurePnpm() {
 
 function ensureGit() {
   try {
-    execSync("git -v");
+    execSync("git --version");
   } catch (err) {
     logger.error(
       `Command not found: ${kleur.yellow(


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/awslabs/green-boost/issues/234

*Description of changes:*

Trivially change `git -v` to `git --version` check to work reliably across different versions of git.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
