### PR TITLE
fix: sql identifiers in postgres template

### DIFF
--- a/.changeset/nine-trees-cough.md
+++ b/.changeset/nine-trees-cough.md
@@ -1,0 +1,5 @@
+---
+"gboost": patch
+---
+
+Fix issue in PostgreSQL templates where SQL identifiers are invalid if app id contains dash. Converts to underscore.

--- a/packages/gboost/src/create/ask.ts
+++ b/packages/gboost/src/create/ask.ts
@@ -41,7 +41,7 @@ const questions: PromptObject<keyof Answers>[] = [
     name: "appId",
     type: "text",
     // Part of CDK Stack name and used as scope to prefix all PNPM workspaces within monorepo
-    // Also cloud formation stacks name restrictions only allow alphanumeric and hyphens
+    // Also cloudformation stacks name restrictions only allow alphanumeric and hyphens
     message: "App ID (lowercase alphanumeric and hyphens only):",
     initial: "myapp",
     validate(v) {

--- a/packages/gboost/src/create/get-template-operations/get-crud-postgres-operations.ts
+++ b/packages/gboost/src/create/get-template-operations/get-crud-postgres-operations.ts
@@ -5,7 +5,7 @@ import type { BaseOperationParams } from "./base-operation-params.js";
 export function getCrudPostgresOperations(
   params: BaseOperationParams
 ): Operation[] {
-  const { destinationPath, templatesDirPath } = params;
+  const { appId, destinationPath, templatesDirPath } = params;
   return [
     {
       type: OperationType.Copy,
@@ -24,6 +24,15 @@ export function getCrudPostgresOperations(
       type: OperationType.Copy,
       sourcePath: resolve(templatesDirPath, "crud-postgres"),
       destinationPath,
+    },
+    {
+      name: "ReplaceGbSqlAppIdToken",
+      type: OperationType.Replace,
+      values: [
+        // SQL identifiers cannot have dashes, must be underscore
+        { find: /{{GB_SQL_APP_ID}}/g, replace: appId.replaceAll("-", "_") },
+      ],
+      sourcePath: destinationPath,
     },
   ];
 }

--- a/packages/gboost/templates/crud-postgres/core/src/db/drizzle/0000_boring_maginty.sql
+++ b/packages/gboost/templates/crud-postgres/core/src/db/drizzle/0000_boring_maginty.sql
@@ -1,7 +1,7 @@
 -- Custom SQL migration file, put you code below!  --
-create schema {{GB_APP_ID}};
-create role {{GB_APP_ID}}_iam_user with login;
-grant rds_iam to {{GB_APP_ID}}_iam_user;
-grant usage on schema {{GB_APP_ID}} to {{GB_APP_ID}}_iam_user;
+create schema {{GB_SQL_APP_ID}};
+create role {{GB_SQL_APP_ID}}_iam_user with login;
+grant rds_iam to {{GB_SQL_APP_ID}}_iam_user;
+grant usage on schema {{GB_SQL_APP_ID}} to {{GB_SQL_APP_ID}}_iam_user;
 -- https://gist.github.com/zaenk/2e9c1936663caae71b212f056b5dfb5f
-alter default privileges in schema {{GB_APP_ID}} grant insert, update, delete, select on tables to {{GB_APP_ID}}_iam_user;
+alter default privileges in schema {{GB_SQL_APP_ID}} grant insert, update, delete, select on tables to {{GB_SQL_APP_ID}}_iam_user;

--- a/packages/gboost/templates/crud-postgres/core/src/db/drizzle/0001_loud_serpent_society.sql
+++ b/packages/gboost/templates/crud-postgres/core/src/db/drizzle/0001_loud_serpent_society.sql
@@ -1,4 +1,4 @@
-CREATE TABLE IF NOT EXISTS "{{GB_APP_ID}}"."item" (
+CREATE TABLE IF NOT EXISTS "{{GB_SQL_APP_ID}}"."item" (
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
 	"description" text NOT NULL,
 	"id" uuid PRIMARY KEY NOT NULL,

--- a/packages/gboost/templates/crud-postgres/core/src/db/drizzle/0002_calm_mandarin.sql
+++ b/packages/gboost/templates/crud-postgres/core/src/db/drizzle/0002_calm_mandarin.sql
@@ -1,1 +1,1 @@
-ALTER TABLE "{{GB_APP_ID}}"."item" ALTER COLUMN "id" SET DEFAULT gen_random_uuid();
+ALTER TABLE "{{GB_SQL_APP_ID}}"."item" ALTER COLUMN "id" SET DEFAULT gen_random_uuid();

--- a/packages/gboost/templates/crud-postgres/core/src/db/schema.ts
+++ b/packages/gboost/templates/crud-postgres/core/src/db/schema.ts
@@ -1,7 +1,7 @@
 // @ts-nocheck
 import { pgSchema } from "drizzle-orm/pg-core";
 
-// schema is created in custom migration file with {{GB_APP_ID}}_iam_user so that DB IAM
+// schema is created in custom migration file with {{GB_SQL_APP_ID}}_iam_user so that DB IAM
 // user has access to all tables within this schema
 // want to use config.appId but https://github.com/drizzle-team/drizzle-kit-mirror/issues/55
-export const schema = pgSchema("{{GB_APP_ID}}");
+export const schema = pgSchema("{{GB_SQL_APP_ID}}");


### PR DESCRIPTION
*Issue #, if available:*
Fix issue in PostgreSQL templates where SQL identifiers are invalid if app id contains dash. Converts to underscore.
*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
